### PR TITLE
Change used terms in the navigation

### DIFF
--- a/modules/definitions/nav.adoc
+++ b/modules/definitions/nav.adoc
@@ -1,3 +1,3 @@
 * Definitions
-** xref:index.adoc[Definitions for Software Architecture]
-** xref:software-architecture/index.adoc[]
+** xref:index.adoc[Relevant Definitions]
+** xref:software-architecture/index.adoc[Software Architecture]


### PR DESCRIPTION
I have changed the terms used for navigating
the section definitions. The new terms should
be clearer then the previous ones.