### PR TITLE
Section Organisation restored

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,6 @@ asciidoc:
 
 nav:
   - modules/definitions/nav.adoc
-  - modules/definitions/nav.adoc
+  - modules/organisation/nav.adoc
   - modules/manifestos/nav.adoc
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Restored the section Organisation in the navigation, which has been delete by one of the last changes.